### PR TITLE
Modified to remove zipping for mkv aips

### DIFF
--- a/scripts/prepare_bag_nozip
+++ b/scripts/prepare_bag_nozip
@@ -1,0 +1,26 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Cwd 'abs_path';
+use 5.010;
+
+my $arg_size = @ARGV;
+die "Usage: prepare_bag path/to/bag_directory [dest]" unless $arg_size == 1 || $arg_size == 2;
+
+my $dest = $ARGV[1] || '.';
+
+my $source = abs_path($ARGV[0]);
+$source =~ /^(.+)\/([^\/]+)\/?$/;
+$source = $1;
+my $filename = $2;
+chdir abs_path($dest);
+
+say "Tarring file";
+my $error = `tar cf $filename.tar -C $source $filename 2>&1`;
+die "Cannot create tar file:\n$error" unless $? == 0;
+my $size = (stat "$filename.tar")[7];
+rename "$filename.tar", "$filename.$size.tar";
+# say "Zipping tar file";
+# $error = `bzip2 $filename.$size.tar`;
+# die "Cannot zip tar file:\n$error" unless $? == 0;

--- a/scripts/tar_zip.py
+++ b/scripts/tar_zip.py
@@ -1,4 +1,4 @@
-# Purpose: if MKV, tar each aip folder. All others: tar and zip each aip folder.
+# Purpose: if MKV, tar ONLY each aip folder. All others: tar and zip each aip folder.
 # Dependencies: prepare_bag perl script, prepare_bag_nozip perl script
 
 import os
@@ -10,11 +10,21 @@ from variables import *
 total = len(os.listdir(aips_directory))
 tarzip_count = 0
 
-# Tar and zip the aips using a Perl script.
-# Separate loop so won't get an error if any files are moved due to errors.
-for item in os.listdir():
-  # Displays a progress count because this step can take a long time.
-  tarzip_count += 1
-  print(f'Tar/zipping AIP {tarzip_count} of {total}.')
 
-  subprocess.run(f'perl {prepare_bag} {item} {aip_staging}/aips-ready-to-ingest/', shell=True)
+if workflow == 'mkv':
+  # Tar the aips using a Perl script.
+  # Separate loop so won't get an error if any files are moved due to errors.
+  for item in os.listdir():
+  # Displays a progress count because this step can take a long time.
+    tarzip_count += 1
+    print(f'Tar/zipping AIP {tarzip_count} of {total}.')
+    subprocess.run(f'perl {prepare_bag_nozip} {item} {aip_staging}/aips-ready-to-ingest/', shell=True)
+      
+else:
+  # Tar and zip the aips using a Perl script.
+  # Separate loop so won't get an error if any files are moved due to errors.
+  for item in os.listdir():
+  # Displays a progress count because this step can take a long time.
+    tarzip_count += 1
+    print(f'Tar/zipping AIP {tarzip_count} of {total}.')
+    subprocess.run(f'perl {prepare_bag} {item} {aip_staging}/aips-ready-to-ingest/', shell=True)

--- a/scripts/tar_zip.py
+++ b/scripts/tar_zip.py
@@ -17,7 +17,7 @@ if workflow == 'mkv':
   for item in os.listdir():
   # Displays a progress count because this step can take a long time.
     tarzip_count += 1
-    print(f'Tar/zipping AIP {tarzip_count} of {total}.')
+    print(f'Tarring AIP {tarzip_count} of {total}.')
     subprocess.run(f'perl {prepare_bag_nozip} {item} {aip_staging}/aips-ready-to-ingest/', shell=True)
       
 else:

--- a/scripts/tar_zip.py
+++ b/scripts/tar_zip.py
@@ -1,5 +1,5 @@
-# Purpose: tar and zip each aip folder.
-# Dependencies: prepare_bag perl script
+# Purpose: if MKV, tar each aip folder. All others: tar and zip each aip folder.
+# Dependencies: prepare_bag perl script, prepare_bag_nozip perl script
 
 import os
 import shutil

--- a/scripts/variables.py
+++ b/scripts/variables.py
@@ -13,6 +13,7 @@ saxon = 'INSERT PATH HERE'
 stylesheet = 'INSERT PATH HERE'
 xsd = 'INSERT PATH HERE'
 prepare_bag = 'INSERT PATH HERE'
+prepare_bag_nozip = 'INSERT PATH HERE'
 
 
 # Variables that are determined from script arguments.


### PR DESCRIPTION
- Added "if" conditional to tar_zip.py to test for mkv workflow. If mkv, script does not zip aip. This change was implemented because compression in mkv files made zipping process redundant.
- Added the prepare_bag_nozip script to repo. This script is the same as prepare_bag except the last 3 lines are commented out
- Updated variables.py to add a variable for where the prepare_bag_nozip script is saved
