### PR TITLE
Mkv filmscan option

### DIFF
--- a/scripts/aip_av.py
+++ b/scripts/aip_av.py
@@ -1,6 +1,6 @@
 # Usage: python3 path/to/aip_av.py workflow_type path/to/aips_directory department
 
-# workflow_type choices are: 'dpx', 'mkv', 'mov', 'mxf'
+# workflow_type choices are: 'dpx', 'mkv', 'mkv-filmscan', 'mov', 'mxf'
 
 # Prepares audiovisual data for ingest into the UGA Libraries Digital Preservation Storage System as an AIP by running a series of scripts in sequence:
 

--- a/scripts/manifest_ingest.py
+++ b/scripts/manifest_ingest.py
@@ -13,7 +13,7 @@ print('\n>>>Making MD5 manifest and moving AIPs to ingest server...\n')
 os.chdir(f'{aip_staging}/aips-ready-to-ingest')
 
 # Set a date variable equal to current date.
-date = datetime.date.today()
+date = datetime.datetime.now().strftime("%Y-%m-%d-%H%M")
 
 #Make MD5 manifest of all packaged AIPs (bagged, tarred, and zipped).
 subprocess.run(f'md5deep -br {os.getcwd()} > {aip_staging}/md5-manifests-for-aips/{date}_AIPs_md5_manifest.txt', shell=True)

--- a/scripts/tar_zip.py
+++ b/scripts/tar_zip.py
@@ -11,7 +11,7 @@ total = len(os.listdir(aips_directory))
 tarzip_count = 0
 
 
-if workflow == 'mkv':
+if workflow == 'mkv' or workflow == 'mkv-filmscan':
   # Tar the aips using a Perl script.
   # Separate loop so won't get an error if any files are moved due to errors.
   for item in os.listdir():

--- a/scripts/verify_fixity.py
+++ b/scripts/verify_fixity.py
@@ -9,7 +9,7 @@ from variables import *
 print('\n>>>Verifying fixity...\n')
 
 # Makes a manifest from the existing sidecar files.
-# NOT TESTED: couldn't get checksumthing configured right on my machine (AH)
+
 subprocess.run(f'checksumthing -i "{aips_directory}" -ie .md5 -t md5 -c lower -r -post \' {{fullpath}}\' -o "{aips_directory}"/oldmd5manifest.txt', shell=True)
 for item in os.listdir():
 


### PR DESCRIPTION
Added a new workflow_type : mkv-filmscan. This allows bypassing of the fixity check via md5deep, which was just throwing errors because these files don't have md5 sidecar files.

Also updated how md5 manifests are named so that more than one md5 manifest can be created per day (added hour and minute to end of filename).